### PR TITLE
Unsafe determine of platform executable

### DIFF
--- a/src/lib/protoc-gen-swagger.ts
+++ b/src/lib/protoc-gen-swagger.ts
@@ -1,15 +1,16 @@
 import { ProtocOptions, protoc } from '@accility/protoc-tools';
 import * as apis from 'google-proto-files';
 import * as path from 'path';
+import * as os from 'os';
 
-const extension = process.platform === 'win32' ? '.exe' : '';
-export function fromProto(options: ProtocOptions) : Promise<void> {
-  options.includeDirs.push(path.resolve(apis.getProtoPath(), '..'));
-  options.plugin = plugin;
-  return protoc(options);
+const extension = os.platform().toLowerCase() === 'win32' ? '.exe' : '';
+export function fromProto(options: ProtocOptions): Promise<void> {
+	options.includeDirs.push(path.resolve(apis.getProtoPath(), '..'));
+	options.plugin = plugin;
+	return protoc(options);
 }
 
 export const plugin = {
-    name: 'swagger',
-    path: path.resolve(__dirname, '../../native/bin', process.platform, process.arch, 'protoc-gen-swagger' + extension),
+	name: 'swagger',
+	path: path.resolve(__dirname, '../../native/bin', os.platform().toLowerCase(), os.arch().toLowerCase(), 'protoc-gen-swagger' + extension),
 }


### PR DESCRIPTION
It's unsafe to `process`' platform or arch in some environments, ex. Virtual machine. The module `os`' platform and arch methods should be used instead.